### PR TITLE
Enable client helper

### DIFF
--- a/src/main/java/com/github/twitch4j/chatbot/Bot.java
+++ b/src/main/java/com/github/twitch4j/chatbot/Bot.java
@@ -95,6 +95,11 @@ public class Bot {
         for (String channel : configuration.getChannels()) {
             twitchClient.getChat().joinChannel(channel);
         }
+
+        // Enable client helper for Stream GoLive / GoOffline / GameChange / TitleChange Events
+        twitchClient.getClientHelper().enableStreamEventListener(configuration.getChannels());
+        // Enable client helper for Follow Event
+        twitchClient.getClientHelper().enableFollowEventListener(configuration.getChannels());
     }
 
     public ITwitchClient getTwitchClient() {


### PR DESCRIPTION
Add enableStreamEventListener enableFollowEventListener to start for get all event from channels. https://twitch4j.github.io/getting-started/client-helper/

### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

* Enable client helper,

### Additional Information

Exemple never register to channels for Stream GoLive / GoOffline / GameChange / TitleChange / Follow Event so we couldn't listen to them.